### PR TITLE
Add useZ to CircleZones

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1050,6 +1050,7 @@ CreateThread(function()
             AddCircleZone(v.name, v.coords, v.radius, {
                 name = v.name,
                 debugPoly = v.debugPoly,
+				useZ = v.useZ,
             }, {
                 options = v.options,
                 distance = v.distance


### PR DESCRIPTION
**Describe Pull request**
Couldn't define useZ option in circle zone. Updated function.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [**yes**/no] (Be honest)
- Does your code fit the style guidelines? [**yes**/no]
- Does your PR fit the contribution guidelines? [**yes**/no]
