### PR TITLE
qtarget changes and interoperability

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -5,8 +5,8 @@ The config is in the init.lua
 ### All the exports have to be on the client-side to work!
 
 ## AddBoxZone / Job Check
-This is an example setup for a police job. The resource defines a BoxZone around a clipboard in the `gabz_mrpd` MLO. 
-It's a simple set-up, we provide a **unique** name, define its center point with the vector3, define a length and a width, and then we define some options; the unique name again, the heading of the box, a bool to display a debug poly, and the height of the zone. 
+This is an example setup for a police job. The resource defines a BoxZone around a clipboard in the `gabz_mrpd` MLO.
+It's a simple set-up, we provide a **unique** name, define its center point with the vector3, define a length and a width, and then we define some options; the unique name again, the heading of the box, a bool to display a debug poly, and the height of the zone.
 
 Then, in the actual options themselves, we define 'police' as our required job.
 
@@ -83,7 +83,7 @@ citizenid = {
 }
 ```
 
-When defining multiple jobs or gangs, you **must** provide a minimum grade, even if you don't need one. This is due to how key/value tables work. Set the minimum grade to the minimum grade of the job if you want everyone to access it. 
+When defining multiple jobs or gangs, you **must** provide a minimum grade, even if you don't need one. This is due to how key/value tables work. Set the minimum grade to the minimum grade of the job if you want everyone to access it.
 
 ## AddTargetModel / item / canInteract()
 
@@ -180,6 +180,40 @@ exports['qb-target']:AddTargetEntity(mule, {
     },
     distance = 3.0
 })
+```
+
+## Add interactable Ped at specific coordinates
+This is an example for adding an interactable Ped with a weapon in given coordinates.
+
+The below `Config.Peds` table is located in `init.lua`.
+
+```lua
+Config.Peds = {
+    {
+        model = `mp_m_securoguard_01`,
+        coords = vector4(433.0, -985.71, 30.71, 26.92),
+        networked = true,
+        invincible = true,
+        blockevents = true,
+        weapon = {
+            name = `weapon_carbinerifle`,
+            ammo = 0,
+            hidden = false,
+        },
+        target = {
+            options = {
+                {
+                    type = "client",
+                    event = "qb-policejob:ToggleDuty",
+                    icon = "fas fa-sign-in-alt",
+                    label = "Sign In",
+                    job = "police",
+                },
+            },
+            distance = 2.5
+        }
+    }
+}
 ```
 
 ## Passing Item Data

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -639,7 +639,7 @@ CreateThread(function()
   local entity = CreatePed(0, model, GetEntityCoords(PlayerPedId()), GetEntityHeading(PlayerPedId()), true, false)
   exports['qb-target']:AddEntityZone("name", entity, { -- The specified entity number
     name = "name", -- This is the name of the zone recognized by PolyZone, this has to be unique so it doesn't mess up with other zones
-    debugPoly = false, -- This is for enabling/disabling the drawing of the box, it accepts only a boolean value (true or false), when true it will draw the polyzone in green 
+    debugPoly = false, -- This is for enabling/disabling the drawing of the box, it accepts only a boolean value (true or false), when true it will draw the polyzone in green
   }, {
     options = { -- This is your options table, in this table all the options will be specified for the target to accept
       { -- This is the first table with options, you can make as many options inside the options table as you want
@@ -1273,6 +1273,16 @@ datatable = {
   anim: string,
   flag: number,
   scenario: string,
+  pedrelations = {
+    groupname: string or number,
+    toowngroup: number,
+    toplayer: number
+  },
+  weapon = {
+    name: string or number,
+    ammo: number,
+    hidden: boolean
+  },
   target = {
     useModel: boolean,
     options = {
@@ -1292,7 +1302,8 @@ datatable = {
     },
     distance: float
   },
-  currentpednumber: number
+  currentpednumber: number,
+  action: function
 }
 
 -- This is for multiple peds
@@ -1308,6 +1319,16 @@ datatable = {
     anim: string,
     flag: number,
     scenario: string,
+    pedrelations = {
+      groupname: string or number,
+      toowngroup: number,
+      toplayer: number
+    },
+    weapon = {
+      name: string or number,
+      ammo: number,
+      hidden: boolean
+    },
     target = {
       useModel: boolean,
       options = {
@@ -1327,7 +1348,8 @@ datatable = {
       },
       distance: float
     },
-    currentpednumber: number
+    currentpednumber: number,
+    action: function
   }
 }
 ```
@@ -1347,6 +1369,16 @@ datatable = {
   anim = 'csb_abigail_dual-0', -- This is the animation that will play chosen from the animDict, this will loop the whole time the ped is spawned (OPTIONAL)
   flag = 1, -- This is the flag of the animation to play, for all the flags, check the TaskPlayAnim native here https://docs.fivem.net/natives/?_0x5AB552C6 (OPTIONAL)
   scenario = 'WORLD_HUMAN_AA_COFFEE', -- This is the scenario that will play the whole time the ped is spawned, this cannot pair with anim and animDict (OPTIONAL)
+  pedrelations = { -- This is the relationship group the ped is apart of, this can be either a custom relationship group or a preexisting one.
+    groupname = 'AMBIENT_GANG_BALLAS',
+    toowngroup = 0, -- relation to their own group defined above.
+    toplayer = 3,  -- relationship to the player. Check values of this native here https://docs.fivem.net/natives/?_0xBF25EB89375A37AD
+  },
+  weapon = { -- This is the ped's weapon table, here you can specify what weapon, the ammo and if the weapon is hidden or not (OPTIONAL)
+    name = 'weapon_carbinerifle', -- This is the weapon weapon that you would like to give the spawned ped
+    ammo = 0, -- This is the amount of ammo you would like for the ped to have
+    hidden = false, -- This is whether or not the weapon will be visibly displayed on the ped when spawned
+  },
   target = { -- This is the target options table, here you can specify all the options to display when targeting the ped (OPTIONAL)
     useModel = false, -- This is the option for which target function to use, when this is set to true it'll use AddTargetModel and add these to al models of the given ped model, if it is false it will only add the options to this specific ped
     options = { -- This is your options table, in this table all the options will be specified for the target to accept
@@ -1374,6 +1406,9 @@ datatable = {
     distance = 2.5, -- This is the distance for you to be at for the target to turn blue, this is in GTA units and has to be a float value
   },
   currentpednumber = 0, -- This is the current ped number, this will be assigned when spawned, you can leave this out because it will always be created (OPTIONAL)
+  action = function(spawnedPedData) -- This is a action that performs upon ped spawn, supplying the data used to spawn the ped OPTIONAL
+    TriggerEvent('testing:event', 'test') -- Triggers a client event called testing:event and sends the argument 'test' with it
+  end,
 },
 ```
 
@@ -1392,6 +1427,16 @@ exports['qb-target']:SpawnPed({
   anim = 'csb_abigail_dual-0', -- This is the animation that will play chosen from the animDict, this will loop the whole time the ped is spawned (OPTIONAL)
   flag = 1, -- This is the flag of the animation to play, for all the flags, check the TaskPlayAnim native here https://docs.fivem.net/natives/?_0x5AB552C6 (OPTIONAL)
   scenario = 'WORLD_HUMAN_AA_COFFEE', -- This is the scenario that will play the whole time the ped is spawned, this cannot pair with anim and animDict (OPTIONAL)
+  pedrelations = { -- This is the relationship group the ped is apart of, this can be either a custom relationship group or a preexisting one.
+    groupname = 'AMBIENT_GANG_BALLAS',
+    toowngroup = 0, -- relation to their own group defined above.
+    toplayer = 3,  -- relationship to the player. Check values of this native here https://docs.fivem.net/natives/?_0xBF25EB89375A37AD
+  },
+  weapon = { -- This is the ped's weapon table, here you can specify what weapon, the ammo and if the weapon is hidden or not (OPTIONAL)
+    name = 'weapon_carbinerifle', -- This is the weapon weapon that you would like to give the spawned ped
+    ammo = 0, -- This is the amount of ammo you would like for the ped to have
+    hidden = false, -- This is whether or not the weapon will be visibly displayed on the ped when spawned
+  },
   target = { -- This is the target options table, here you can specify all the options to display when targeting the ped (OPTIONAL)
     useModel = false, -- This is the option for which target function to use, when this is set to true it'll use AddTargetModel and add these to al models of the given ped model, if it is false it will only add the options to this specific ped
     options = { -- This is your options table, in this table all the options will be specified for the target to accept
@@ -1419,6 +1464,9 @@ exports['qb-target']:SpawnPed({
     distance = 2.5, -- This is the distance for you to be at for the target to turn blue, this is in GTA units and has to be a float value
   },
   currentpednumber = 0, -- This is the current ped number, this will be assigned when spawned, you can leave this out because it will always be created (OPTIONAL)
+  action = function(spawnedPedData) -- This is a action that performs upon ped spawn, supplying the data used to spawn the ped OPTIONAL
+    TriggerEvent('testing:event', 'test') -- Triggers a client event called testing:event and sends the argument 'test' with it
+  end,
 })
 
 -- This is for multiple peds, here I used 2 of the same peds
@@ -1434,6 +1482,16 @@ exports['qb-target']:SpawnPed({
     anim = 'csb_abigail_dual-0', -- This is the animation that will play chosen from the animDict, this will loop the whole time the ped is spawned (OPTIONAL)
     flag = 1, -- This is the flag of the animation to play, for all the flags, check the TaskPlayAnim native here https://docs.fivem.net/natives/?_0x5AB552C6 (OPTIONAL)
     scenario = 'WORLD_HUMAN_AA_COFFEE', -- This is the scenario that will play the whole time the ped is spawned, this cannot pair with anim and animDict (OPTIONAL)
+    pedrelations = { -- This is the relationship group the ped is apart of, this can be either a custom relationship group or a preexisting one.
+      groupname = 'AMBIENT_GANG_BALLAS',
+      toowngroup = 0, -- relation to their own group defined above.
+      toplayer = 3,  -- relationship to the player. Check values of this native here https://docs.fivem.net/natives/?_0xBF25EB89375A37AD
+    },
+    weapon = { -- This is the ped's weapon table, here you can specify what weapon, the ammo and if the weapon is hidden or not (OPTIONAL)
+      name = 'weapon_carbinerifle', -- This is the weapon weapon that you would like to give the spawned ped
+      ammo = 0, -- This is the amount of ammo you would like for the ped to have
+      hidden = false, -- This is whether or not the weapon will be visibly displayed on the ped when spawned
+    },
     target = { -- This is the target options table, here you can specify all the options to display when targeting the ped (OPTIONAL)
       useModel = false, -- This is the option for which target function to use, when this is set to true it'll use AddTargetModel and add these to al models of the given ped model, if it is false it will only add the options to this specific ped
       options = { -- This is your options table, in this table all the options will be specified for the target to accept
@@ -1461,6 +1519,9 @@ exports['qb-target']:SpawnPed({
       distance = 2.5, -- This is the distance for you to be at for the target to turn blue, this is in GTA units and has to be a float value
     },
     currentpednumber = 0, -- This is the current ped number, this will be assigned when spawned, you can leave this out because it will always be created (OPTIONAL)
+    action = function(spawnedPedData) -- This is a action that performs upon ped spawn, supplying the data used to spawn the ped OPTIONAL
+      TriggerEvent('testing:event', 'test') -- Triggers a client event called testing:event and sends the argument 'test' with it
+    end,
   },
   [2] = {
     model = 'a_m_m_indian_01', -- This is the ped model that is going to be spawning at the given coords
@@ -1473,6 +1534,16 @@ exports['qb-target']:SpawnPed({
     anim = 'csb_abigail_dual-0', -- This is the animation that will play chosen from the animDict, this will loop the whole time the ped is spawned (OPTIONAL)
     flag = 1, -- This is the flag of the animation to play, for all the flags, check the TaskPlayAnim native here https://docs.fivem.net/natives/?_0x5AB552C6 (OPTIONAL)
     scenario = 'WORLD_HUMAN_AA_COFFEE', -- This is the scenario that will play the whole time the ped is spawned, this cannot pair with anim and animDict (OPTIONAL)
+    pedrelations = { -- This is the relationship group the ped is apart of, this can be either a custom relationship group or a preexisting one.
+      groupname = 'AMBIENT_GANG_BALLAS',
+      toowngroup = 0, -- relation to their own group defined above.
+      toplayer = 3,  -- relationship to the player. Check values of this native here https://docs.fivem.net/natives/?_0xBF25EB89375A37AD
+    },
+    weapon = { -- This is the ped's weapon table, here you can specify what weapon, the ammo and if the weapon is hidden or not (OPTIONAL)
+      name = 'weapon_carbinerifle', -- This is the weapon weapon that you would like to give the spawned ped
+      ammo = 0, -- This is the amount of ammo you would like for the ped to have
+      hidden = false, -- This is whether or not the weapon will be visibly displayed on the ped when spawned
+    },
     target = { -- This is the target options table, here you can specify all the options to display when targeting the ped (OPTIONAL)
       useModel = false, -- This is the option for which target function to use, when this is set to true it'll use AddTargetModel and add these to al models of the given ped model, if it is false it will only add the options to this specific ped
       options = { -- This is your options table, in this table all the options will be specified for the target to accept
@@ -1500,6 +1571,9 @@ exports['qb-target']:SpawnPed({
       distance = 2.5, -- This is the distance for you to be at for the target to turn blue, this is in GTA units and has to be a float value
     },
     currentpednumber = 0, -- This is the current ped number, this will be assigned when spawned, you can leave this out because it will always be created (OPTIONAL)
+    action = function(spawnedPedData) -- This is a action that performs upon ped spawn, supplying the data used to spawn the ped OPTIONAL
+      TriggerEvent('testing:event', 'test') -- Triggers a client event called testing:event and sends the argument 'test' with it
+    end,
   }
 })
 ```

--- a/client.lua
+++ b/client.lua
@@ -1180,6 +1180,7 @@ CreateThread(function()
             AddCircleZone(v.name, v.coords, v.radius, {
                 name = v.name,
                 debugPoly = v.debugPoly,
+				useZ = v.useZ,
             }, {
                 options = v.options,
                 distance = v.distance

--- a/client.lua
+++ b/client.lua
@@ -19,12 +19,14 @@ local DrawSprite = DrawSprite
 local ClearDrawOrigin = ClearDrawOrigin
 local HasStreamedTextureDictLoaded = HasStreamedTextureDictLoaded
 local RequestStreamedTextureDict = RequestStreamedTextureDict
+local HasEntityClearLosToEntity = HasEntityClearLosToEntity
 local currentResourceName = GetCurrentResourceName()
 local Config, Types, Players, Entities, Models, Zones, nuiData, sendData, sendDistance = Config, {{}, {}, {}}, {}, {}, {}, {}, {}, {}, {}
 local playerPed, targetActive, hasFocus, success, pedsReady, allowTarget = PlayerPedId(), false, false, false, false, true
 local screen = {}
 local table_wipe = table.wipe
 local pairs = pairs
+local pcall = pcall
 local CheckOptions = CheckOptions
 local Bones = Load('bones')
 local listSprite = {}
@@ -199,8 +201,6 @@ local function SetupOptions(datatable, entity, distance, isZone)
 	end
 	return slot
 end
-
-exports('SetupOptions', SetupOptions)
 
 local function CheckEntity(flag, datatable, entity, distance)
 	if not next(datatable) then return end
@@ -498,8 +498,6 @@ local function SetOptions(tbl, distance, options)
 	end
 end
 
-exports("SetOptions", SetOptions)
-
 local function AddTargetBone(bones, parameters)
 	local distance, options = parameters.distance or Config.MaxDistance, parameters.options
 	if type(bones) == 'table' then
@@ -767,7 +765,7 @@ function SpawnPeds()
 					Wait(0)
 				end
 
-				TaskPlayAnim(spawnedped, v.animDict, v.anim, 8.0, 0, -1, v.flag or 1, 0, 0, 0, 0)
+				TaskPlayAnim(spawnedped, v.animDict, v.anim, 8.0, 0, -1, v.flag or 1, 0, false, false, false)
 			end
 
 			if v.scenario then
@@ -876,7 +874,7 @@ local function SpawnPed(data)
 						Wait(0)
 					end
 
-					TaskPlayAnim(spawnedped, v.animDict, v.anim, 8.0, 0, -1, v.flag or 1, 0, 0, 0, 0)
+					TaskPlayAnim(spawnedped, v.animDict, v.anim, 8.0, 0, -1, v.flag or 1, 0, false, false, false)
 				end
 
 				if v.scenario then
@@ -972,7 +970,7 @@ local function SpawnPed(data)
 					Wait(0)
 				end
 
-				TaskPlayAnim(spawnedped, data.animDict, data.anim, 8.0, 0, -1, data.flag or 1, 0, 0, 0, 0)
+				TaskPlayAnim(spawnedped, data.animDict, data.anim, 8.0, 0, -1, data.flag or 1, 0, false, false, false)
 			end
 
 			if data.scenario then
@@ -1054,64 +1052,92 @@ exports("RemoveSpawnedPed", RemovePed)
 
 -- Misc. Exports
 
-exports("RemoveGlobalPed", function(labels) RemoveGlobalType(1, labels) end)
+local function RemoveGlobalPed(labels) RemoveGlobalType(1, labels) end
+exports("RemoveGlobalPed", RemoveGlobalPed)
 
-exports("RemoveGlobalVehicle", function(labels) RemoveGlobalType(2, labels) end)
+local function RemoveGlobalVehicle(labels) RemoveGlobalType(2, labels) end
+exports("RemoveGlobalVehicle", RemoveGlobalVehicle)
 
-exports("RemoveGlobalObject", function(labels) RemoveGlobalType(3, labels) end)
+local function RemoveGlobalObject(labels) RemoveGlobalType(3, labels) end
+exports("RemoveGlobalObject", RemoveGlobalObject)
 
-exports("IsTargetActive", function() return targetActive end)
+local function IsTargetActive() return targetActive end
+exports("IsTargetActive", IsTargetActive)
 
-exports("IsTargetSuccess", function() return success end)
+local function IsTargetSuccess() return success end
+exports("IsTargetSuccess", IsTargetSuccess)
 
-exports("GetGlobalTypeData", function(type, label) return Types[type][label] end)
+local function GetGlobalTypeData(type, label) return Types[type][label] end
+exports("GetGlobalTypeData", GetGlobalTypeData)
 
-exports("GetZoneData", function(name) return Zones[name] end)
+local function GetZoneData(name) return Zones[name] end
+exports("GetZoneData", GetZoneData)
 
-exports("GetTargetBoneData", function(bone, label) return Bones.Options[bone][label] end)
+local function GetTargetBoneData(bone, label) return Bones.Options[bone][label] end
+exports("GetTargetBoneData", GetTargetBoneData)
 
-exports("GetTargetEntityData", function(entity, label) return Entities[entity][label] end)
+local function GetTargetEntityData(entity, label) return Entities[entity][label] end
+exports("GetTargetEntityData", GetTargetEntityData)
 
-exports("GetTargetModelData", function(model, label) return Models[model][label] end)
+local function GetTargetModelData(model, label) return Models[model][label] end
+exports("GetTargetModelData", GetTargetModelData)
 
-exports("GetGlobalPedData", function(label) return Types[1][label] end)
+local function GetGlobalPedData(label) return Types[1][label] end
+exports("GetGlobalPedData", GetGlobalPedData)
 
-exports("GetGlobalVehicleData", function(label) return Types[2][label] end)
+local function GetGlobalVehicleData(label) return Types[2][label] end
+exports("GetGlobalVehicleData", GetGlobalVehicleData)
 
-exports("GetGlobalObjectData", function(label) return Types[3][label] end)
+local function GetGlobalObjectData(label) return Types[3][label] end
+exports("GetGlobalObjectData", GetGlobalObjectData)
 
-exports("GetGlobalPlayerData", function(label) return Players[label] end)
+local function GetGlobalPlayerData(label) return Players[label] end
+exports("GetGlobalPlayerData", GetGlobalPlayerData)
 
-exports("UpdateGlobalTypeData", function(type, label, data) Types[type][label] = data end)
+local function UpdateGlobalTypeData(type, label, data) Types[type][label] = data end
+exports("UpdateGlobalTypeData", UpdateGlobalTypeData)
 
-exports("UpdateZoneData", function(name, data)
+local function UpdateZoneData(name, data)
 	data.distance = data.distance or Config.MaxDistance
 	Zones[name].targetoptions = data
-end)
+end
+exports("UpdateZoneData", UpdateZoneData)
 
-exports("UpdateTargetBoneData", function(bone, label, data) Bones.Options[bone][label] = data end)
+local function UpdateTargetBoneData(bone, label, data) Bones.Options[bone][label] = data end
+exports("UpdateTargetBoneData", UpdateTargetBoneData)
 
-exports("UpdateTargetEntityData", function(entity, label, data) Entities[entity][label] = data end)
+local function UpdateTargetEntityData(entity, label, data) Entities[entity][label] = data end
+exports("UpdateTargetEntityData", UpdateTargetEntityData)
 
-exports("UpdateTargetModelData", function(model, label, data) Models[model][label] = data end)
+local function UpdateTargetModelData(model, label, data) Models[model][label] = data end
+exports("UpdateTargetModelData", UpdateTargetModelData)
 
-exports("UpdateGlobalPedData", function(label, data) Types[1][label] = data end)
+local function UpdateGlobalPedData(label, data) Types[1][label] = data end
+exports("UpdateGlobalPedData", UpdateGlobalPedData)
 
-exports("UpdateGlobalVehicleData", function(label, data) Types[2][label] = data end)
+local function UpdateGlobalVehicleData(label, data) Types[2][label] = data end
+exports("UpdateGlobalVehicleData", UpdateGlobalVehicleData)
 
-exports("UpdateGlobalObjectData", function(label, data) Types[3][label] = data end)
+local function UpdateGlobalObjectData(label, data) Types[3][label] = data end
+exports("UpdateGlobalObjectData", UpdateGlobalObjectData)
 
-exports("UpdateGlobalPlayerData", function(label, data) Players[label] = data end)
+local function UpdateGlobalPlayerData(label, data) Players[label] = data end
+exports("UpdateGlobalPlayerData", UpdateGlobalPlayerData)
 
-exports("GetPeds", function() return Config.Peds end)
+local function GetPeds() return Config.Peds end
+exports("GetPeds", GetPeds)
 
-exports("UpdatePedsData", function(index, data) Config.Peds[index] = data end)
+local function UpdatePedsData(index, data) Config.Peds[index] = data end
+exports("UpdatePedsData", UpdatePedsData)
 
-exports("AllowTargeting", function(bool)
+local function AllowTargeting(bool)
 	allowTarget = bool
+
 	if allowTarget then return end
+
 	DisableTarget(true)
-end)
+end
+exports("AllowTargeting", AllowTargeting)
 
 -- NUI Callbacks
 
@@ -1286,3 +1312,62 @@ end)
 -- Debug Option
 
 if Config.Debug then Load('debug') end
+
+-- qtarget interoperability
+
+local qtargetExports = {
+	["raycast"] = RaycastCamera,
+	["DisableNUI"] = DisableNUI,
+	["LeaveTarget"] = LeftTarget,
+	["DisableTarget"] = DisableTarget,
+	["DrawOutlineEntity"] = DrawOutlineEntity,
+	["CheckEntity"] = CheckEntity,
+	["CheckBones"] = CheckBones,
+	["AddCircleZone"] = AddCircleZone,
+	["AddBoxZone"] = AddBoxZone,
+	["AddPolyZone"] = AddPolyZone,
+	["AddComboZone"] = AddComboZone,
+	["AddEntityZone"] = AddEntityZone,
+	["RemoveZone"] = RemoveZone,
+	["AddTargetBone"] = AddTargetBone,
+	["RemoveTargetBone"] = RemoveTargetBone,
+	["AddTargetEntity"] = AddTargetEntity,
+	["RemoveTargetEntity"] = RemoveTargetEntity,
+	["AddTargetModel"] = AddTargetModel,
+	["RemoveTargetModel"] = RemoveTargetModel,
+	["Ped"] = AddGlobalPed,
+	["Vehicle"] = AddGlobalVehicle,
+	["Object"] = AddGlobalObject,
+	["Player"] = AddGlobalPlayer,
+	["RemovePed"] = RemoveGlobalPed,
+	["RemoveVehicle"] = RemoveGlobalVehicle,
+	["RemoveObject"] = RemoveGlobalObject,
+	["RemovePlayer"] = RemoveGlobalPlayer,
+	["IsTargetActive"] = IsTargetActive,
+	["IsTargetSuccess"] = IsTargetSuccess,
+	["GetType"] = GetGlobalTypeData,
+	["GetZone"] = GetZoneData,
+	["GetTargetBone"] = GetTargetBoneData,
+	["GetTargetEntity"] = GetTargetEntityData,
+	["GetTargetModel"] = GetTargetModelData,
+	["GetPed"] = GetGlobalPedData,
+	["GetVehicle"] = GetGlobalVehicleData,
+	["GetObject"] = GetGlobalObjectData,
+	["GetPlayer"] = GetGlobalPlayerData,
+	["UpdateType"] = UpdateGlobalTypeData,
+	["UpdateZoneOptions"] = UpdateZoneData,
+	["UpdateTargetBone"] = UpdateTargetBoneData,
+	["UpdateTargetEntity"] = UpdateTargetEntityData,
+	["UpdateTargetModel"] = UpdateTargetModelData,
+	["UpdatePed"] = UpdateGlobalPedData,
+	["UpdateVehicle"] = UpdateGlobalVehicleData,
+	["UpdateObject"] = UpdateGlobalObjectData,
+	["UpdatePlayer"] = UpdateGlobalPlayerData,
+	["AllowTargeting"] = AllowTargeting
+}
+
+for exportName, func in pairs(qtargetExports) do
+	AddEventHandler(('__cfx_export_qtarget_%s'):format(exportName), function(setCB)
+		setCB(func)
+	end)
+end

--- a/client.lua
+++ b/client.lua
@@ -731,6 +731,35 @@ function SpawnPeds()
 				TaskStartScenarioInPlace(spawnedped, v.scenario, 0, true)
 			end
 
+			if v.pedrelations then
+				if type(v.pedrelations.groupname) ~= 'string' then error(v.pedrelations.groupname .. ' is not a string') end
+
+				local pedgrouphash = joaat(v.pedrelations.groupname)
+
+				if not DoesRelationshipGroupExist(pedgrouphash) then
+					AddRelationshipGroup(v.pedrelations.groupname)
+				end
+
+				SetPedRelationshipGroupHash(spawnedped, pedgrouphash)
+				if v.pedrelations.toplayer then
+					SetRelationshipBetweenGroups(v.pedrelations.toplayer, pedgrouphash, joaat('PLAYER'))
+				end
+
+				if v.pedrelations.toowngroup then
+					SetRelationshipBetweenGroups(v.pedrelations.toowngroup, pedgrouphash, pedgrouphash)
+				end
+			end
+
+			if v.weapon then
+				if type(v.weapon.name) == 'string' then v.weapon.name = joaat(v.weapon.name) end
+
+				if IsWeaponValid(v.weapon.name) then
+					SetCanPedEquipWeapon(spawnedped, v.weapon.name, true)
+					GiveWeaponToPed(spawnedped, v.weapon.name, v.weapon.ammo, v.weapon.hidden or false, true)
+					SetPedCurrentWeaponVisible(spawnedped, not v.weapon.hidden or false, true)
+				end
+			end
+
 			if v.target then
 				if v.target.useModel then
 					AddTargetModel(v.model, {
@@ -743,6 +772,10 @@ function SpawnPeds()
 						distance = v.target.distance
 					})
 				end
+			end
+
+			if v.action then
+				v.action(v)
 			end
 
 			Config.Peds[k].currentpednumber = spawnedped
@@ -807,6 +840,35 @@ local function SpawnPed(data)
 					TaskStartScenarioInPlace(spawnedped, v.scenario, 0, true)
 				end
 
+				if v.pedrelations and type(v.pedrelations.groupname) == 'string' then
+					if type(v.pedrelations.groupname) ~= 'string' then error(v.pedrelations.groupname .. ' is not a string') end
+
+					local pedgrouphash = joaat(v.pedrelations.groupname)
+
+					if not DoesRelationshipGroupExist(pedgrouphash) then
+						AddRelationshipGroup(v.pedrelations.groupname)
+					end
+
+					SetPedRelationshipGroupHash(spawnedped, pedgrouphash)
+					if v.pedrelations.toplayer then
+						SetRelationshipBetweenGroups(v.pedrelations.toplayer, pedgrouphash, joaat('PLAYER'))
+					end
+
+					if v.pedrelations.toowngroup then
+						SetRelationshipBetweenGroups(v.pedrelations.toowngroup, pedgrouphash, pedgrouphash)
+					end
+				end
+
+				if v.weapon then
+					if type(v.weapon.name) == 'string' then v.weapon.name = joaat(v.weapon.name) end
+
+					if IsWeaponValid(v.weapon.name) then
+						SetCanPedEquipWeapon(spawnedped, v.weapon.name, true)
+						GiveWeaponToPed(spawnedped, v.weapon.name, v.weapon.ammo, v.weapon.hidden or false, true)
+						SetPedCurrentWeaponVisible(spawnedped, not v.weapon.hidden or false, true)
+					end
+				end
+
 				if v.target then
 					if v.target.useModel then
 						AddTargetModel(v.model, {
@@ -822,6 +884,10 @@ local function SpawnPed(data)
 				end
 
 				v.currentpednumber = spawnedped
+
+				if v.action then
+					v.action(v)
+				end
 			end
 
 			local nextnumber = #Config.Peds + 1
@@ -870,6 +936,35 @@ local function SpawnPed(data)
 				TaskStartScenarioInPlace(spawnedped, data.scenario, 0, true)
 			end
 
+			if data.pedrelations then
+				if type(data.pedrelations.groupname) ~= 'string' then error(data.pedrelations.groupname .. ' is not a string') end
+
+				local pedgrouphash = joaat(data.pedrelations.groupname)
+
+				if not DoesRelationshipGroupExist(pedgrouphash) then
+					AddRelationshipGroup(data.pedrelations.groupname)
+				end
+
+				SetPedRelationshipGroupHash(spawnedped, pedgrouphash)
+				if data.pedrelations.toplayer then
+					SetRelationshipBetweenGroups(data.pedrelations.toplayer, pedgrouphash, joaat('PLAYER'))
+				end
+
+				if data.pedrelations.toowngroup then
+					SetRelationshipBetweenGroups(data.pedrelations.toowngroup, pedgrouphash, pedgrouphash)
+				end
+			end
+
+			if data.weapon then
+				if type(data.weapon.name) == 'string' then data.weapon.name = joaat(data.weapon.name) end
+
+				if IsWeaponValid(data.weapon.name) then
+					SetCanPedEquipWeapon(spawnedped, data.weapon.name, true)
+					GiveWeaponToPed(spawnedped, data.weapon.name, data.weapon.ammo, data.weapon.hidden or false, true)
+					SetPedCurrentWeaponVisible(spawnedped, not data.weapon.hidden or false, true)
+				end
+			end
+
 			if data.target then
 				if data.target.useModel then
 					AddTargetModel(data.model, {
@@ -882,6 +977,10 @@ local function SpawnPed(data)
 						distance = data.target.distance
 					})
 				end
+			end
+
+			if data.action then
+				data.action(data)
 			end
 
 			data.currentpednumber = spawnedped

--- a/client.lua
+++ b/client.lua
@@ -506,29 +506,37 @@ exports("AddTargetBone", AddTargetBone)
 local function RemoveTargetBone(bones, labels)
 	if type(bones) == 'table' then
 		for _, bone in pairs(bones) do
-			if type(labels) == 'table' then
-				for _, v in pairs(labels) do
+			if labels then
+				if type(labels) == 'table' then
+					for _, v in pairs(labels) do
+						if Bones.Options[bone] then
+							Bones.Options[bone][v] = nil
+						end
+					end
+				elseif type(labels) == 'string' then
 					if Bones.Options[bone] then
-						Bones.Options[bone][v] = nil
+						Bones.Options[bone][labels] = nil
 					end
 				end
-			elseif type(labels) == 'string' then
-				if Bones.Options[bone] then
-					Bones.Options[bone][labels] = nil
-				end
+			else
+				Bones.Options[bone] = nil
 			end
 		end
 	else
-		if type(labels) == 'table' then
-			for _, v in pairs(labels) do
+		if labels then
+			if type(labels) == 'table' then
+				for _, v in pairs(labels) do
+					if Bones.Options[bones] then
+						Bones.Options[bones][v] = nil
+					end
+				end
+			elseif type(labels) == 'string' then
 				if Bones.Options[bones] then
-					Bones.Options[bones][v] = nil
+					Bones.Options[bones][labels] = nil
 				end
 			end
-		elseif type(labels) == 'string' then
-			if Bones.Options[bones] then
-				Bones.Options[bones][labels] = nil
-			end
+		else
+			Bones.Options[bones] = nil
 		end
 	end
 end
@@ -556,30 +564,38 @@ local function RemoveTargetEntity(entities, labels)
 	if type(entities) == 'table' then
 		for _, entity in pairs(entities) do
 			if NetworkGetEntityIsNetworked(entity) then entity = NetworkGetNetworkIdFromEntity(entity) end -- Allow non-networked entities to be targeted
-			if type(labels) == 'table' then
-				for _, v in pairs(labels) do
+			if labels then
+				if type(labels) == 'table' then
+					for _, v in pairs(labels) do
+						if Entities[entity] then
+							Entities[entity][v] = nil
+						end
+					end
+				elseif type(labels) == 'string' then
 					if Entities[entity] then
-						Entities[entity][v] = nil
+						Entities[entity][labels] = nil
 					end
 				end
-			elseif type(labels) == 'string' then
-				if Entities[entity] then
-					Entities[entity][labels] = nil
-				end
+			else
+				Entities[entity] = nil
 			end
 		end
 	elseif type(entities) == 'number' then
 		if NetworkGetEntityIsNetworked(entities) then entities = NetworkGetNetworkIdFromEntity(entities) end -- Allow non-networked entities to be targeted
-		if type(labels) == 'table' then
-			for _, v in pairs(labels) do
+		if labels then
+			if type(labels) == 'table' then
+				for _, v in pairs(labels) do
+					if Entities[entities] then
+						Entities[entities][v] = nil
+					end
+				end
+			elseif type(labels) == 'string' then
 				if Entities[entities] then
-					Entities[entities][v] = nil
+					Entities[entities][labels] = nil
 				end
 			end
-		elseif type(labels) == 'string' then
-			if Entities[entities] then
-				Entities[entities][labels] = nil
-			end
+		else
+			Entities[entities] = nil
 		end
 	end
 end
@@ -607,30 +623,38 @@ local function RemoveTargetModel(models, labels)
 	if type(models) == 'table' then
 		for _, model in pairs(models) do
 			if type(model) == 'string' then model = joaat(model) end
-			if type(labels) == 'table' then
-				for _, v in pairs(labels) do
+			if labels then
+				if type(labels) == 'table' then
+					for _, v in pairs(labels) do
+						if Models[model] then
+							Models[model][v] = nil
+						end
+					end
+				elseif type(labels) == 'string' then
 					if Models[model] then
-						Models[model][v] = nil
+						Models[model][labels] = nil
 					end
 				end
-			elseif type(labels) == 'string' then
-				if Models[model] then
-					Models[model][labels] = nil
-				end
+			else
+				Models[model] = nil
 			end
 		end
 	else
 		if type(models) == 'string' then models = joaat(models) end
-		if type(labels) == 'table' then
-			for _, v in pairs(labels) do
+		if labels then
+			if type(labels) == 'table' then
+				for _, v in pairs(labels) do
+					if Models[models] then
+						Models[models][v] = nil
+					end
+				end
+			elseif type(labels) == 'string' then
 				if Models[models] then
-					Models[models][v] = nil
+					Models[models][labels] = nil
 				end
 			end
-		elseif type(labels) == 'string' then
-			if Models[models] then
-				Models[models][labels] = nil
-			end
+		else
+			Models[models] = nil
 		end
 	end
 end
@@ -664,24 +688,32 @@ end
 exports("AddGlobalPlayer", AddGlobalPlayer)
 
 local function RemoveGlobalType(typ, labels)
-	if type(labels) == 'table' then
-		for _, v in pairs(labels) do
-			Types[typ][v] = nil
+	if labels then
+		if type(labels) == 'table' then
+			for _, v in pairs(labels) do
+				Types[typ][v] = nil
+			end
+		elseif type(labels) == 'string' then
+			Types[typ][labels] = nil
 		end
-	elseif type(labels) == 'string' then
-		Types[typ][labels] = nil
+	else
+		Types[typ] = {}
 	end
 end
 
 exports("RemoveGlobalType", RemoveGlobalType)
 
 local function RemoveGlobalPlayer(labels)
-	if type(labels) == 'table' then
-		for _, v in pairs(labels) do
-			Players[v] = nil
+	if labels then
+		if type(labels) == 'table' then
+			for _, v in pairs(labels) do
+				Players[v] = nil
+			end
+		elseif type(labels) == 'string' then
+			Players[labels] = nil
 		end
-	elseif type(labels) == 'string' then
-		Players[labels] = nil
+	else
+		Players = {}
 	end
 end
 
@@ -1062,9 +1094,8 @@ exports("UpdatePedsData", function(index, data) Config.Peds[index] = data end)
 
 exports("AllowTargeting", function(bool)
 	allowTarget = bool
-	if not allowTarget then
-		DisableTarget(true)
-	end
+	if allowTarget then return end
+	DisableTarget(true)
 end)
 
 -- NUI Callbacks
@@ -1144,7 +1175,7 @@ CreateThread(function()
 		TriggerEvent('chat:removeSuggestion', '/-playerTarget')
 	end
 
-    if next(Config.CircleZones) then
+    if table.type(Config.CircleZones) ~= 'empty' then
         for _, v in pairs(Config.CircleZones) do
             AddCircleZone(v.name, v.coords, v.radius, {
                 name = v.name,
@@ -1156,7 +1187,7 @@ CreateThread(function()
         end
     end
 
-    if next(Config.BoxZones) then
+    if table.type(Config.BoxZones) ~= 'empty' then
         for _, v in pairs(Config.BoxZones) do
             AddBoxZone(v.name, v.coords, v.length, v.width, {
                 name = v.name,
@@ -1171,7 +1202,7 @@ CreateThread(function()
         end
     end
 
-    if next(Config.PolyZones) then
+    if table.type(Config.PolyZones) ~= 'empty' then
         for _, v in pairs(Config.PolyZones) do
             AddPolyZone(v.name, v.points, {
                 name = v.name,
@@ -1185,7 +1216,7 @@ CreateThread(function()
         end
     end
 
-    if next(Config.TargetBones) then
+    if table.type(Config.TargetBones) ~= 'empty' then
         for _, v in pairs(Config.TargetBones) do
             AddTargetBone(v.bones, {
                 options = v.options,
@@ -1194,7 +1225,7 @@ CreateThread(function()
         end
     end
 
-    if next(Config.TargetModels) then
+    if table.type(Config.TargetModels) ~= 'empty' then
         for _, v in pairs(Config.TargetModels) do
             AddTargetModel(v.models, {
                 options = v.options,
@@ -1203,19 +1234,19 @@ CreateThread(function()
         end
     end
 
-    if next(Config.GlobalPedOptions) then
+    if table.type(Config.GlobalPedOptions) ~= 'empty' then
         AddGlobalPed(Config.GlobalPedOptions)
     end
 
-    if next(Config.GlobalVehicleOptions) then
+    if table.type(Config.GlobalVehicleOptions) ~= 'empty' then
         AddGlobalVehicle(Config.GlobalVehicleOptions)
     end
 
-    if next(Config.GlobalObjectOptions) then
+    if table.type(Config.GlobalObjectOptions) ~= 'empty' then
         AddGlobalObject(Config.GlobalObjectOptions)
     end
 
-    if next(Config.GlobalPlayerOptions) then
+    if table.type(Config.GlobalPlayerOptions) ~= 'empty' then
         AddGlobalPlayer(Config.GlobalPlayerOptions)
     end
 end)
@@ -1224,16 +1255,14 @@ end)
 
 -- This is to make sure the peds spawn on restart too instead of only when you load/log-in.
 AddEventHandler('onResourceStart', function(resource)
-	if resource == currentResourceName then
-		SpawnPeds()
-	end
+	if resource ~= currentResourceName then return end
+	SpawnPeds()
 end)
 
 -- This will delete the peds when the resource stops to make sure you don't have random peds walking
 AddEventHandler('onResourceStop', function(resource)
-	if resource == currentResourceName then
-		DeletePeds()
-	end
+	if resource ~= currentResourceName then return end
+	DeletePeds()
 end)
 
 -- Debug Option

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 
 author 'BerkieB'
 description 'An optimized interaction system for FiveM, based on qtarget'
-version '5.3.9'
+version '5.4.0'
 
 ui_page 'html/index.html'
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -25,6 +25,6 @@ files {
 }
 
 lua54 'yes'
-use_fxv2_oal 'yes'
+use_experimental_fxv2_oal 'yes'
 
 dependency 'PolyZone'

--- a/html/index.html
+++ b/html/index.html
@@ -20,7 +20,7 @@
     <!-- CSS File Import -->
     <link href="css/style.css" rel="stylesheet" type="text/css" />
     <!-- Vue Import -->
-    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.global.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.global.prod.min.js" defer></script>
     <!-- Quasar JS Import -->
     <script src="https://cdn.jsdelivr.net/npm/quasar/dist/quasar.umd.min.js" defer></script>
     <!-- JavaScript File Import -->

--- a/init.lua
+++ b/init.lua
@@ -142,37 +142,7 @@ CreateThread(function()
 		local QBCore = exports['qb-core']:GetCoreObject()
 		local PlayerData = QBCore.Functions.GetPlayerData()
 
-		ItemCheck = function(items)
-			local isTable = type(items) == 'table'
-			local isArray = isTable and table.type(items) == 'array' or false
-			local finalcount = 0
-			local count = 0
-			if isTable then for _ in pairs(items) do finalcount += 1 end end
-			for _, v in pairs(PlayerData.items) do
-				if isTable then
-					if isArray then -- Table expected in this format {'itemName1', 'itemName2', 'etc'}
-						for _, item in pairs(items) do
-							if v and v.name == item then
-								count += 1
-							end
-						end
-					else -- Table expected in this format {['itemName'] = amount}
-						local itemAmount = items[v.name]
-						if itemAmount and v and v.amount >= itemAmount then
-							count += 1
-						end
-					end
-					if count == finalcount then -- This is to make sure it checks all items in the table instead of only one of the items
-						return true
-					end
-				else -- When items is a string
-					if v and v.name == items then
-						return true
-					end
-				end
-			end
-			return false
-		end
+		ItemCheck = QBCore.Functions.HasItem
 
 		JobCheck = function(job)
 			if type(job) == 'table' then


### PR DESCRIPTION
**Describe Pull request**
- Fixed updating zones not working because updating the whole zone table breaks it
- Fix wrong coords on bones checker in loop
- Fix oal not being enabled due to the new name for the flag being implemented
- Replaced the raycast flag and added a los check:
"Some entities aren't hit by raycasts when interacting with the world,
which is why we alternate flags. When using flag 30, check line-of-sight
to ensure it's not being hit through a wall.
Reduced raycast length from 10000 to 16, and collider to 7.

Didn't notice anything break from this, but needs confirmation."
\- Linden

- EnableTarget runs in a thread now, it needs to because a command function isn't in a thread already so calling yielding functions (for example wait) will cause silent errors
- Support objects with invalid types:
"Some entities will return an entity type of 0 ("no entity"), despite clearly
being an entity. Calling GetEntityModel either returns a model, or throws
a native invocation error.
Use a protected call for GetEntityModel and treat anything with a model
as an object.

Notably fixes interaction with (most?) trees, who knows what else."
\- Linden

- qtarget exports now directly work with qb-target without needing to change `exports.qtarget` to `exports['qb-target']`
- Added useZ to AddCircleZone config

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
