### PR TITLE
Was able to open locked car doors with target

### DIFF
--- a/data/bones.lua
+++ b/data/bones.lua
@@ -43,7 +43,7 @@ if Config.EnableDefaultOptions then
     }
 
     local function ToggleDoor(vehicle, door)
-        if GetVehicleDoorLockStatus(vehicle) ~= 2 then
+        if GetVehicleDoorLockStatus(vehicle) < 2 then
             if GetVehicleDoorAngleRatio(vehicle, door) > 0.0 then
                 SetVehicleDoorShut(vehicle, door, false)
             else


### PR DESCRIPTION
Patched an area of the code so now you are unable to open locked car doors when qb-target EnableDefaultOption is true



If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
