### PR TITLE
fix(client): Fix inconsistently targeting models

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -101,7 +101,7 @@ local function RaycastCamera(flag, playerCoords)
 
 	local rayPos, rayDir = ScreenPositionToCameraRay()
 	local destination = rayPos + 16 * rayDir
-	local rayHandle = StartShapeTestLosProbe(rayPos.x, rayPos.y, rayPos.z, destination.x, destination.y, destination.z, flag or -1, playerPed, 7)
+	local rayHandle = StartShapeTestLosProbe(rayPos.x, rayPos.y, rayPos.z, destination.x, destination.y, destination.z, flag or -1, playerPed, 4)
 
 	while true do
 		local result, _, endCoords, _, entityHit = GetShapeTestResult(rayHandle)


### PR DESCRIPTION
**Describe Pull request**
Switches the flag for `StartShapeTestLosProbe` from `7` to `4` to fix weird issues with inconsistent target models. 

Upgrading from 5.3.9=>5.4.0, many models were unable to be targeted, mostly identified immediately with road signs. After debugging thoroughly, I identified this change. Changing the bitmask to 4 fixes the issues encountered and all expected targets were able to be targeted. I also tried accessing a target inside of another target (storage container), and sitting in a chair through a wall - was unable to do either as expected.

After further review, I noticed changing the bitmask to 4 was also in the upstream qtarget.

If your PR is to fix an issue mention that issue here

This may resolve #158 if it's still an active issue. I tried to replicate but was unable to.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) The raycasting portions yes
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes
