### PR TITLE
Minor tweak: Add return to SpawnPed to return the entityid

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1032,6 +1032,7 @@ local function SpawnPed(data)
 		if nextnumber <= 0 then nextnumber = 1 end
 
 		Config.Peds[nextnumber] = data
+		return spawnedped
 	end
 end
 


### PR DESCRIPTION
**Describe Pull request**
Currently, despawning a ped spawned with SpawnPed seem to be a bit of a hassle. There seem to be no way to get the entityid in a smart way other than through the "getPeds" export.

This VERY minor addition would make it so using the export SpawnPed can also return the entityid. Makes handling cleanup and deletion a walk in the park, as now the spawned ped can be assigned to something in a simple way.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
