### PR TITLE
tweak(client): getting screen ratio & fov on start

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1293,6 +1293,9 @@ CreateThread(function()
     if table.type(Config.GlobalPlayerOptions) ~= 'empty' then
         AddGlobalPlayer(Config.GlobalPlayerOptions)
     end
+
+    screen.ratio = GetAspectRatio(true)
+    screen.fov = GetFinalRenderedCamFov()
 end)
 
 -- Events


### PR DESCRIPTION
**Describe Pull request**
I am initializing the variable `screen` on resource start.

If we use an export, for example RaycastCamera and we didn't open the target yet it will give a error on function ScreenPositionToCameraRay saying that screen.fov is equal to nil.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
