### PR TITLE
feat: include entity coords if entity is defined

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -191,9 +191,6 @@ local function SetupOptions(datatable, entity, distance, isZone)
 			slot = data.num or slot + 1
 			sendData[slot] = data
 			sendData[slot].entity = entity
-			if entity then
-				sendData[slot].coords = GetEntityCoords(entity)
-			end
 			nuiData[slot] = {
 				icon = data.icon,
 				targeticon = data.targeticon,
@@ -1195,6 +1192,9 @@ RegisterNUICallback('selectTarget', function(option, cb)
 	table_wipe(sendData)
 	CreateThread(function()
 		Wait(0)
+		if data.entity ~= nil then
+			data.coords = GetEntityCoords(data.entity)
+		end
 		if data.action then
 			data.action(data.entity)
 		elseif data.event then

--- a/client.lua
+++ b/client.lua
@@ -191,6 +191,9 @@ local function SetupOptions(datatable, entity, distance, isZone)
 			slot = data.num or slot + 1
 			sendData[slot] = data
 			sendData[slot].entity = entity
+			if entity then
+				sendData[slot].coords = GetEntityCoords(entity)
+			end
 			nuiData[slot] = {
 				icon = data.icon,
 				targeticon = data.targeticon,

--- a/client.lua
+++ b/client.lua
@@ -390,7 +390,7 @@ local function EnableTarget()
 					if data and next(data) then CheckEntity(flag, data, entity, distance) end
 				end
 			else
-				sleep += 20
+				sleep = sleep + 20
 			end
 			if not success then
 				-- Zone targets
@@ -436,14 +436,14 @@ local function EnableTarget()
 						DrawOutlineEntity(entity, false)
 					end
 				else
-					sleep += 20
+					sleep = sleep + 20
 				end
 			else
 				LeftTarget()
 				DrawOutlineEntity(entity, false)
 			end
 		else
-			sleep += 20
+			sleep = sleep + 20
 		end
 		Wait(sleep)
 	end

--- a/init.lua
+++ b/init.lua
@@ -122,7 +122,7 @@ CreateThread(function()
 	if state ~= 'missing' then
 		local timeout = 0
 		while state ~= 'started' and timeout <= 100 do
-			timeout += 1
+			timeout = timeout + 1
 			state = GetResourceState('qb-core')
 			Wait(0)
 		end


### PR DESCRIPTION
**Describe Pull request**
This PR makes sure that the coordinates of said entity are included in the data passed upon trigger events.
This is useful as you can't fetch these coordinateson the server side.

This solves an issue in the inventory, where the vending machines are defined via `AddTargetModel`.
https://github.com/qbcore-framework/qb-inventory/blob/ed5388d2430cbd24d187b984bd827c4f38425a9c/client/main.lua#L274-L286
To later be used via a server event, which requires the coordinates, but are undefined/null at the moment as there's no way of fetching them.
https://github.com/qbcore-framework/qb-inventory/blob/ed5388d2430cbd24d187b984bd827c4f38425a9c/server/main.lua#L142

This needs to be merged alongside this PR:
https://github.com/qbcore-framework/qb-inventory/pull/518

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all its functionality?
> yes
- Does your code fit the style guidelines?
> yes
- Does your PR fit the contribution guidelines?
> yes
