### PR TITLE
fix: PolyZone has vec2 centre, not vec3. Correct for distance check.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -401,7 +401,8 @@ local function EnableTarget()
 						closestZone = zone
 					end
 					if Config.DrawSprite then
-						if #(coords - zone.center) < (zone.targetoptions.drawDistance or Config.DrawDistance) then
+						local testCentre = type(zone.center) == 'vector2' and vector3(zone.center.x, zone.center.y, zone.maxZ) or zone.center
+						if #(coords - testCentre) < (zone.targetoptions.drawDistance or Config.DrawDistance) then
 							listSprite[k] = zone
 						else
 							listSprite[k] = nil


### PR DESCRIPTION
**Describe Pull request**
PolyZones have a vector2 centre, not a vector3. Fix distance calculation for PolyZones when Config.DrawSprite is true.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
