### PR TITLE
Return Ped Entity from spawnPed Function for Improved Management and Deletion

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -971,7 +971,7 @@ local function SpawnPed(data)
 			if nextnumber <= 0 then nextnumber = 1 end
 
 			Config.Peds[nextnumber] = v
-			createdPeds[#createdPeds+1] = nextnumber
+			createdPeds[#createdPeds + 1] = v.currentpednumber
 		end
 	else
 		if data.spawnNow then
@@ -1073,7 +1073,7 @@ local function SpawnPed(data)
 		if nextnumber <= 0 then nextnumber = 1 end
 
 		Config.Peds[nextnumber] = data
-		createdPeds[#createdPeds+1] = nextnumber
+		createdPeds[#createdPeds + 1] = data.currentpednumber
 	end
 	return createdPeds
 end
@@ -1081,20 +1081,25 @@ end
 exports('SpawnPed', SpawnPed)
 
 local function RemovePed(peds)
-	if type(peds) == 'table' then
-		for _, v in ipairs(peds) do
-			if Config.Peds[v] then
-				SetEntityAsNoLongerNeeded(Config.Peds[v].currentpednumber)
-				DeletePed(Config.Peds[v].currentpednumber)
-				Config.Peds[v] = nil
+
+	local function removePedByNumber(pedNumber)
+			for i = #Config.Peds, 1, -1 do -- Reverse loop to avoid index issues
+					local ped = Config.Peds[i]
+					if ped.currentpednumber == pedNumber then
+							SetEntityAsNoLongerNeeded(ped.currentpednumber)
+							DeletePed(ped.currentpednumber)
+							table.remove(Config.Peds, i)
+							break
+					end
 			end
-		end
+	end
+
+	if type(peds) == 'table' then
+			for _, pedNumber in pairs(peds) do
+					removePedByNumber(pedNumber)
+			end
 	elseif type(peds) == 'number' then
-		if Config.Peds[peds] then
-			SetEntityAsNoLongerNeeded(Config.Peds[peds].currentpednumber)
-			DeletePed(Config.Peds[peds].currentpednumber)
-			Config.Peds[peds] = nil
-		end
+			removePedByNumber(peds)
 	end
 end
 

--- a/client.lua
+++ b/client.lua
@@ -869,6 +869,7 @@ exports('DeletePeds', DeletePeds)
 local function SpawnPed(data)
 	local spawnedped
 	local key, value = next(data)
+	local createdPeds = {}
 	if type(value) == 'table' and type(key) ~= 'string' then
 		for _, v in pairs(data) do
 			if v.spawnNow then
@@ -970,6 +971,7 @@ local function SpawnPed(data)
 			if nextnumber <= 0 then nextnumber = 1 end
 
 			Config.Peds[nextnumber] = v
+			createdPeds[#createdPeds+1] = nextnumber
 		end
 	else
 		if data.spawnNow then
@@ -1071,19 +1073,28 @@ local function SpawnPed(data)
 		if nextnumber <= 0 then nextnumber = 1 end
 
 		Config.Peds[nextnumber] = data
+		createdPeds[#createdPeds+1] = nextnumber
 	end
+	return createdPeds
 end
 
 exports('SpawnPed', SpawnPed)
 
 local function RemovePed(peds)
 	if type(peds) == 'table' then
-		for k, v in pairs(peds) do
-			DeletePed(v)
-			if Config.Peds[k] then Config.Peds[k].currentpednumber = 0 end
+		for _, v in ipairs(peds) do
+			if Config.Peds[v] then
+				SetEntityAsNoLongerNeeded(Config.Peds[v].currentpednumber)
+				DeletePed(Config.Peds[v].currentpednumber)
+				Config.Peds[v] = nil
+			end
 		end
 	elseif type(peds) == 'number' then
-		DeletePed(peds)
+		if Config.Peds[peds] then
+			SetEntityAsNoLongerNeeded(Config.Peds[peds].currentpednumber)
+			DeletePed(Config.Peds[peds].currentpednumber)
+			Config.Peds[peds] = nil
+		end
 	end
 end
 


### PR DESCRIPTION
**Describe Pull Request**

This pull request addresses the issue where the `spawnPed` function does not return the ped entity, which prevents proper management and deletion of the peds after they are spawned. By updating the function to return the ped, it will allow developers to manage spawned peds more effectively, including actions like tracking, modifying, or deleting them later in the script.

### What this PR adds or fixes:
- **Fix**: The `spawnPed` function now returns the ped entity after creation.
- **Reason**: This modification is crucial for managing the peds, enabling more flexible control such as proper cleanup or updates to their state, which was previously not possible without having access to the ped entity reference.

This change ensures better ped lifecycle management, especially in scenarios where multiple peds are created and need to be tracked or handled individually.

### Issue
This PR fixes the issue where peds created by the `spawnPed` function were not returned, making it difficult to control or delete them later.

---

**Questions:**
- Have you personally loaded this code into an updated qbcore project and checked all its functionality? [yes/no] (I created a script to try with peds in Config.Peds)
- Does your code fit the style guidelines? [yes]  
- Does your PR fit the contribution guidelines? [yes]